### PR TITLE
CheckNotTestsNamespaceOutsideTestsDirectoryRule

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -29,10 +29,10 @@ services:
 		tags:
 			- phpstan.rules.rules
 
-	# - # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#checknottestsnamespaceoutsidetestsdirectoryrule
-	# 	class: Symplify\PHPStanRules\Rules\CheckNotTestsNamespaceOutsideTestsDirectoryRule
-	# 	tags:
-	# 		- phpstan.rules.rule
+	- # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#checknottestsnamespaceoutsidetestsdirectoryrule
+		class: Symplify\PHPStanRules\Rules\CheckNotTestsNamespaceOutsideTestsDirectoryRule
+		tags:
+			- phpstan.rules.rule
 
 	# - # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#checksprintfmatchingtypesrule
 	# 	class: Symplify\PHPStanRules\Rules\Missing\CheckSprintfMatchingTypesRule


### PR DESCRIPTION
"*Test.php" file cannot be located outside "Tests" namespace

- class: [`Symplify\PHPStanRules\Rules\CheckNotTestsNamespaceOutsideTestsDirectoryRule`](../src/Rules/CheckNotTestsNamespaceOutsideTestsDirectoryRule.php)

```php
// file: "SomeTest.php
namespace App;

class SomeTest
{
}
```

:x:

<br>

```php
// file: "SomeTest.php
namespace App\Tests;

class SomeTest
{
}
```

:+1: