### PR TITLE
CheckSprintfMatchingTypesRule [Will fail on Lychee & php-exif]

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -34,10 +34,10 @@ services:
 	# 	tags:
 	# 		- phpstan.rules.rule
 
-	# - # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#checksprintfmatchingtypesrule
-	# 	class: Symplify\PHPStanRules\Rules\Missing\CheckSprintfMatchingTypesRule
-	# 	tags:
-	# 		- phpstan.rules.rule
+	- # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#checksprintfmatchingtypesrule
+		class: Symplify\PHPStanRules\Rules\Missing\CheckSprintfMatchingTypesRule
+		tags:
+			- phpstan.rules.rule
 
 	# - # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#forbiddenanonymousclassrule
 	# 	class: Symplify\PHPStanRules\Rules\ForbiddenAnonymousClassRule


### PR DESCRIPTION

`sprintf()` call mask types does not match provided arguments types

- class: [`Symplify\PHPStanRules\Rules\Missing\CheckSprintfMatchingTypesRule`](../src/Rules/Missing/CheckSprintfMatchingTypesRule.php)

```php
echo sprintf('My name is %s and I have %d children', 10, 'Tomas');
```

:x:

<br>

```php
echo sprintf('My name is %s and I have %d children', 'Tomas', 10);
```

:+1:
