### PR TITLE
Forbidden Func Call Rule

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -49,15 +49,15 @@ services:
 	# 	tags:
 	# 		- phpstan.rules.rule
 
-	# - # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#forbiddenfunccallrule
-	# 	class: Symplify\PHPStanRules\Rules\ForbiddenFuncCallRule
-	# 	tags:
-	# 		- phpstan.rules.rule
-	# 	arguments:
-	# 		forbiddenFunctions:
-	# 			eval: 'eval is not allowed'
-	# 			dd: 'seems you missed some dd debugging function'
-	# 			dump: 'seems you missed some dump debugging function'
+	- # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#forbiddenfunccallrule
+		class: Symplify\PHPStanRules\Rules\ForbiddenFuncCallRule
+		tags:
+			- phpstan.rules.rule
+		arguments:
+			forbiddenFunctions:
+				eval: 'eval is not allowed'
+				dd: 'seems you missed some dd debugging function'
+				dump: 'seems you missed some dump debugging function'
 
 	# - # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#forbiddenmultipleclasslikeinonefilerule
 	# 	class: Symplify\PHPStanRules\Rules\ForbiddenMultipleClassLikeInOneFileRule


### PR DESCRIPTION
Function `"%s()"` cannot be used/left in the code

:wrench: **configure it!**

- class: [`Symplify\PHPStanRules\Rules\ForbiddenFuncCallRule`](../src/Rules/ForbiddenFuncCallRule.php)

```yaml
services:
    -
        class: Symplify\PHPStanRules\Rules\ForbiddenFuncCallRule
        tags: [phpstan.rules.rule]
        arguments:
            forbiddenFunctions:
                - eval
```

↓

```php
echo eval('...');
```

:x:

<br>

```php
echo '...';
```

:+1:

<br>

```yaml
services:
    -
        class: Symplify\PHPStanRules\Rules\ForbiddenFuncCallRule
        tags: [phpstan.rules.rule]
        arguments:
            forbiddenFunctions:
                dump: 'seems you missed some debugging function'
```

↓

```php
dump($value);
echo $value;
```

:x:

<br>

```php
echo $value;
```

:+1:

<br>