### PR TITLE
ForbiddenMultipleClassLikeInOneFileRule [Will fail on Lychee]

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -59,10 +59,10 @@ services:
 	# 			dd: 'seems you missed some dd debugging function'
 	# 			dump: 'seems you missed some dump debugging function'
 
-	# - # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#forbiddenmultipleclasslikeinonefilerule
-	# 	class: Symplify\PHPStanRules\Rules\ForbiddenMultipleClassLikeInOneFileRule
-	# 	tags:
-	# 		- phpstan.rules.rule
+	- # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#forbiddenmultipleclasslikeinonefilerule
+		class: Symplify\PHPStanRules\Rules\ForbiddenMultipleClassLikeInOneFileRule
+		tags:
+			- phpstan.rules.rule
 
 	# - # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#forbiddenparamtyperemovalrule
 	# 	class: Symplify\PHPStanRules\Rules\ForbiddenParamTypeRemovalRule


### PR DESCRIPTION

Multiple class/interface/trait is not allowed in single file

- class: [`Symplify\PHPStanRules\Rules\ForbiddenMultipleClassLikeInOneFileRule`](../src/Rules/ForbiddenMultipleClassLikeInOneFileRule.php)

```php
// src/SomeClass.php
class SomeClass
{
}

interface SomeInterface
{
}
```

:x:

<br>

```php
// src/SomeClass.php
class SomeClass
{
}

// src/SomeInterface.php
interface SomeInterface
{
}
```

:+1:
