### PR TITLE
noabstractmethodrule [Will fail on Lychee]

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -104,10 +104,10 @@ services:
 	# 	tags:
 	# 		- phpstan.rules.rule
 
-	# - # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#noabstractmethodrule
-	# 	class: Symplify\PHPStanRules\Rules\NoAbstractMethodRule
-	# 	tags:
-	# 		- phpstan.rules.rule
+	- # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#noabstractmethodrule
+		class: Symplify\PHPStanRules\Rules\NoAbstractMethodRule
+		tags:
+			- phpstan.rules.rule
 
 	# - # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#noconstantinterfacerule
 	# 	class: Symplify\PHPStanRules\Rules\Enum\NoConstantInterfaceRule


### PR DESCRIPTION

Use explicit interface contract or a service over unclear abstract methods

- class: [`Symplify\PHPStanRules\Rules\NoAbstractMethodRule`](../src/Rules/NoAbstractMethodRule.php)

```php
abstract class SomeClass
{
    abstract public function run();
}
```

:x:

<br>

```php
abstract class SomeClass implements RunnableInterface
{
}

interface RunnableInterface
{
    public function run();
}
```

:+1:

<br>