### PR TITLE
NoConstantInterfaceRule [Will fail on Lychee & php-exif]

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -109,10 +109,10 @@ services:
 	# 	tags:
 	# 		- phpstan.rules.rule
 
-	# - # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#noconstantinterfacerule
-	# 	class: Symplify\PHPStanRules\Rules\Enum\NoConstantInterfaceRule
-	# 	tags:
-	# 		- phpstan.rules.rule
+	- # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#noconstantinterfacerule
+		class: Symplify\PHPStanRules\Rules\Enum\NoConstantInterfaceRule
+		tags:
+			- phpstan.rules.rule
 
 	# - # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#nomissingarrayshapereturnarrayrule
 	# 	class: Symplify\PHPStanRules\Rules\Explicit\NoMissingArrayShapeReturnArrayRule


### PR DESCRIPTION
Reserve interface for contract only. Move constant holder to a class soon-to-be Enum

- class: [`Symplify\PHPStanRules\Rules\Enum\NoConstantInterfaceRule`](../src/Rules/Enum/NoConstantInterfaceRule.php)

```php
interface SomeContract
{
    public const YES = 'yes';

    public const NO = 'no';
}
```

:x:

<br>

```php
class SomeValues
{
    public const YES = 'yes';

    public const NO = 'no';
}
```

:+1:

<br>