### PR TITLE
NoMissingArrayShapeReturnArrayRule [Will fail on Lychee]

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -114,10 +114,10 @@ services:
 	# 	tags:
 	# 		- phpstan.rules.rule
 
-	# - # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#nomissingarrayshapereturnarrayrule
-	# 	class: Symplify\PHPStanRules\Rules\Explicit\NoMissingArrayShapeReturnArrayRule
-	# 	tags:
-	# 		- phpstan.rules.rule
+	- # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#nomissingarrayshapereturnarrayrule
+		class: Symplify\PHPStanRules\Rules\Explicit\NoMissingArrayShapeReturnArrayRule
+		tags:
+			- phpstan.rules.rule
 
 	# - # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#nomixedarraydimfetchrule
 	# 	class: Symplify\PHPStanRules\Rules\Explicit\NoMixedArrayDimFetchRule


### PR DESCRIPTION


Complete known array shape to the method `@return` type

- class: [`Symplify\PHPStanRules\Rules\Explicit\NoMissingArrayShapeReturnArrayRule`](../src/Rules/Explicit/NoMissingArrayShapeReturnArrayRule.php)

```php
function run(string $name)
{
    return ['name' => $name];
}
```

:x:

<br>

```php
/**
 * @return array{name: string}
 */
function run(string $name)
{
    return ['name' => $name];
}
```

:+1:

<br>
