### PR TITLE
NoNullableArrayPropertyRule [Will fail on Lychee]

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -124,10 +124,10 @@ services:
 	# 	tags:
 	# 		- phpstan.rules.rule
 
-	# - # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#nonullablearraypropertyrule
-	# 	class: Symplify\PHPStanRules\Rules\NoNullableArrayPropertyRule
-	# 	tags:
-	# 		- phpstan.rules.rule
+	- # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#nonullablearraypropertyrule
+		class: Symplify\PHPStanRules\Rules\NoNullableArrayPropertyRule
+		tags:
+			- phpstan.rules.rule
 
 	# - # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#noprotectedelementinfinalclassrule
 	# 	class: Symplify\PHPStanRules\Rules\NoProtectedElementInFinalClassRule


### PR DESCRIPTION
Use required typed property over of nullable array property

- class: [`Symplify\PHPStanRules\Rules\NoNullableArrayPropertyRule`](../src/Rules/NoNullableArrayPropertyRule.php)

```php
final class SomeClass
{
    private ?array $property = null;
}
```

:x:

<br>

```php
final class SomeClass
{
    private array $property = [];
}
```

:+1: