### PR TITLE
NoProtectedElementInFinalClassRule [Will fail on Lychee]

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -129,10 +129,10 @@ services:
 	# 	tags:
 	# 		- phpstan.rules.rule
 
-	# - # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#noprotectedelementinfinalclassrule
-	# 	class: Symplify\PHPStanRules\Rules\NoProtectedElementInFinalClassRule
-	# 	tags:
-	# 		- phpstan.rules.rule
+	- # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#noprotectedelementinfinalclassrule
+		class: Symplify\PHPStanRules\Rules\NoProtectedElementInFinalClassRule
+		tags:
+			- phpstan.rules.rule
 
 	# - # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#prefixabstractclassrule
 	# 	class: Symplify\PHPStanRules\Rules\PrefixAbstractClassRule


### PR DESCRIPTION

Instead of protected element in final class use private element or contract method

- class: [`Symplify\PHPStanRules\Rules\NoProtectedElementInFinalClassRule`](../src/Rules/NoProtectedElementInFinalClassRule.php)

```php
final class SomeClass
{
    protected function run()
    {
    }
}
```

:x:

<br>

```php
final class SomeClass
{
    private function run()
    {
    }
}
```

:+1:

<br>