### PR TITLE
UppercaseConstantRule

### DIFF
--- a/phpstan.neon
+++ b/phpstan.neon
@@ -139,10 +139,10 @@ services:
 	# 	tags:
 	# 		- phpstan.rules.rule
 
-	# - # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#uppercaseconstantrule
-	# 	class: Symplify\PHPStanRules\Rules\UppercaseConstantRule
-	# 	tags:
-	# 		- phpstan.rules.rule
+	- # https://github.com/symplify/phpstan-rules/blob/main/docs/rules_overview.md#uppercaseconstantrule
+		class: Symplify\PHPStanRules\Rules\UppercaseConstantRule
+		tags:
+			- phpstan.rules.rule
 
 parameters:
 	level: 7


### PR DESCRIPTION

Constant "%s" must be uppercase

- class: [`Symplify\PHPStanRules\Rules\UppercaseConstantRule`](../src/Rules/UppercaseConstantRule.php)

```php
final class SomeClass
{
    public const some = 'value';
}
```

:x:

<br>

```php
final class SomeClass
{
    public const SOME = 'value';
}
```

:+1:

<br>